### PR TITLE
Set Npgsql Timestampt Behavior

### DIFF
--- a/Entities/Models/DbContexts/ModelsDbContext.cs
+++ b/Entities/Models/DbContexts/ModelsDbContext.cs
@@ -58,8 +58,8 @@ public class ModelsDbContext : IdentityDbContext<ApplicationUser, IdentityRole<G
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder
-            .AddInterceptors(new LocalToUtcInterceptor())
-            .AddInterceptors(new UtcToLocalInterceptor());
+        // optionsBuilder
+        //     .AddInterceptors(new LocalToUtcInterceptor())
+        //     .AddInterceptors(new UtcToLocalInterceptor());
     }
 }

--- a/WebApp/Program.cs
+++ b/WebApp/Program.cs
@@ -1,4 +1,3 @@
-using BusinessLayer.JobScheduler.JobConfiguration;
 using Entities.Models;
 using Entities.Models.DbContexts;
 using Microsoft.AspNetCore.Identity;
@@ -6,6 +5,8 @@ using Quartz;
 using Quartz.Impl;
 using WebApp;
 using WebApp.JobScheduler;
+
+AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -50,7 +51,7 @@ builder.Services.AddSingleton<WebAppStartupJobsTrigger>();
 
 // add razon runtime compilation
 #if DEBUG
-    builder.Services.AddMvc().AddRazorRuntimeCompilation();
+builder.Services.AddMvc().AddRazorRuntimeCompilation();
 #endif
 
 WebApplication app = builder.Build();


### PR DESCRIPTION
Por ahora, se comentan los interceptores.
Con este cambio se hace que el funcionamiento de Npgsql ignore el DateTimeKind de los DateTimes. Dado que trabajamos con una sóla región podríamos dejar este cambio pero me gustaría usar los interceptores en el futuro para un mejor funcionamiento.
También debería chequear que el "LocalTime" sea el del usuario y no el del servidor